### PR TITLE
⚙️SET: Common 디렉토리를 Global 디렉토리로 이동하기

### DIFF
--- a/aptner/src/main/java/com/fastcampus/aptner/global/common/BaseTimeEntity.java
+++ b/aptner/src/main/java/com/fastcampus/aptner/global/common/BaseTimeEntity.java
@@ -1,4 +1,4 @@
-package com.fastcampus.aptner.common;
+package com.fastcampus.aptner.global.common;
 
 import jakarta.persistence.*;
 import lombok.Getter;

--- a/aptner/src/main/java/com/fastcampus/aptner/member/domain/Member.java
+++ b/aptner/src/main/java/com/fastcampus/aptner/member/domain/Member.java
@@ -1,13 +1,10 @@
 package com.fastcampus.aptner.member.domain;
 
 
-import com.fastcampus.aptner.common.BaseTimeEntity;
+import com.fastcampus.aptner.global.common.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.*;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
 
-import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 


### PR DESCRIPTION
## Description
지난 Common 디렉토리와 Global 디렉토리의 의미가 겹치는 부분이 있다.

따라서 Global 디렉토리 안에 공통된 사항을 작성한다.

## Key Changes

- 기존의 Common 디렉토리를 Global 디렉토리로 이동
  - Common 디렉토리 안의 BaseEntity 또한 함께 이동한다.


## To Reviewers
@cutegyuseok @NaSJ93 

This closes #14 