### PR TITLE
✨ENH: 인증 성공과 실패 핸들러 작성하기

### DIFF
--- a/aptner/build.gradle
+++ b/aptner/build.gradle
@@ -34,11 +34,37 @@ dependencies {
 
 	// 1. Spring Security
 	implementation 'org.springframework.boot:spring-boot-starter-security'
+	testImplementation 'org.springframework.security:spring-security-test'
 
 	// 2. swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+
+	// 3. gson
+	// https://mvnrepository.com/artifact/com.google.code.gson/gson
+	implementation 'com.google.code.gson:gson:2.10.1'
+
+	// 4. querydsl
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+	// 5. jjwt
+	// https://mvnrepository.com/artifact/io.jsonwebtoken/jjwt-api
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+	// 6. 테스트에서 Lombok 사용하기
+	testCompileOnly 'org.projectlombok:lombok'
+	testAnnotationProcessor 'org.projectlombok:lombok'
+
 }
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+clean {
+	delete file('src/main/generated')
 }

--- a/aptner/src/main/java/com/fastcampus/aptner/auth/config/CustomSecurityConfig.java
+++ b/aptner/src/main/java/com/fastcampus/aptner/auth/config/CustomSecurityConfig.java
@@ -1,11 +1,14 @@
 package com.fastcampus.aptner.auth.config;
 
+import com.fastcampus.aptner.member.security.handler.APILoginFailHandler;
+import com.fastcampus.aptner.member.security.handler.APILoginSuccessHandler;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
@@ -23,13 +26,23 @@ public class CustomSecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 
-        http.authorizeHttpRequests(authorizationManagerRequestMatcherRegistry ->
-                authorizationManagerRequestMatcherRegistry.anyRequest().permitAll());
-
+        // cors 설정
         http.cors(httpSecurityCorsConfigurer ->
                 httpSecurityCorsConfigurer.configurationSource(corsConfigurationSource()));
 
+        // session 비활성화
+        http.sessionManagement(session ->
+                session.sessionCreationPolicy(SessionCreationPolicy.NEVER));
+
+        // csrf 비활성화
         http.csrf(AbstractHttpConfigurer::disable);
+
+        // 폼 로그인 설정
+        http.formLogin(form -> {
+            form.loginPage("/api/member/login");
+            form.successHandler(new APILoginSuccessHandler());
+            form.failureHandler(new APILoginFailHandler());
+        });
 
         return http.build();
     }

--- a/aptner/src/main/java/com/fastcampus/aptner/member/domain/Member.java
+++ b/aptner/src/main/java/com/fastcampus/aptner/member/domain/Member.java
@@ -11,6 +11,7 @@ import java.util.List;
 
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
 @ToString(exclude = "memberRoleList")
 @Builder
 @Entity
@@ -33,6 +34,7 @@ public class Member extends BaseTimeEntity {
     private Boolean socialLogin;
 
     @ElementCollection(fetch = FetchType.LAZY)
+    @Enumerated(EnumType.STRING)
     @Builder.Default
     private List<MemberRole> memberRoleList = new ArrayList<>();
 

--- a/aptner/src/main/java/com/fastcampus/aptner/member/dto/MemberDTO.java
+++ b/aptner/src/main/java/com/fastcampus/aptner/member/dto/MemberDTO.java
@@ -1,0 +1,52 @@
+package com.fastcampus.aptner.member.dto;
+
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class MemberDTO extends User {
+
+    private String email;
+    private String password;
+    private String nickname;
+    private String content;
+    private String phone;
+    private boolean socialLogin;
+    private List<String> roleNames = new ArrayList<>(); // 프론트에서 처리하기 편한 형태
+
+
+    public MemberDTO(String email, String password, String nickname, String content, String phone, Boolean socialLogin, List<String> roleNames) {
+        super(
+                email,
+                password,
+                roleNames.stream().map(str -> new SimpleGrantedAuthority("ROLE_" + str)).toList()
+        );
+
+        this.email = email;
+        this.password = password;
+        this.nickname = nickname;
+        this.content = content;
+        this.phone = phone;
+        this.socialLogin = socialLogin;
+        this.roleNames = roleNames;
+    }
+
+
+    public Map<String, Object> getClaims() {
+        Map<String, Object> dataMap = new HashMap<>();
+
+        dataMap.put("email", email);
+        dataMap.put("password", password);
+        dataMap.put("nickname", nickname);
+        dataMap.put("content", content);
+        dataMap.put("phone", phone);
+        dataMap.put("socialLogin", socialLogin);
+        dataMap.put("roleNames", roleNames);
+
+        return dataMap;
+    }
+}

--- a/aptner/src/main/java/com/fastcampus/aptner/member/repository/MemberRepository.java
+++ b/aptner/src/main/java/com/fastcampus/aptner/member/repository/MemberRepository.java
@@ -6,10 +6,12 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.Optional;
+
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
     @EntityGraph(attributePaths = {"memberRoleList"})
-    @Query("select m from Member m where m.id= :id")
-    Member getWithRoles(@Param("id") Long id);
+    @Query("select m from Member m where m.email= :email")
+    Optional<Member> getWithRoles(@Param("email") String email);
 
 }

--- a/aptner/src/main/java/com/fastcampus/aptner/member/security/CustomUserDetailsService.java
+++ b/aptner/src/main/java/com/fastcampus/aptner/member/security/CustomUserDetailsService.java
@@ -1,0 +1,36 @@
+package com.fastcampus.aptner.member.security;
+
+import com.fastcampus.aptner.member.domain.Member;
+import com.fastcampus.aptner.member.dto.MemberDTO;
+import com.fastcampus.aptner.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Log4j2
+@RequiredArgsConstructor
+@Service
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+
+        Member member = memberRepository.getWithRoles(username).orElseThrow();
+
+        return new MemberDTO(
+                member.getEmail(),
+                member.getPassword(),
+                member.getNickname(),
+                member.getContent(),
+                member.getPhone(),
+                member.getSocialLogin(),
+                member.getMemberRoleList()
+                        .stream().map(Enum::name).toList()
+        );
+    }
+}

--- a/aptner/src/main/java/com/fastcampus/aptner/member/security/handler/APILoginFailHandler.java
+++ b/aptner/src/main/java/com/fastcampus/aptner/member/security/handler/APILoginFailHandler.java
@@ -1,0 +1,30 @@
+package com.fastcampus.aptner.member.security.handler;
+
+import com.google.gson.Gson;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Map;
+
+@Service
+public class APILoginFailHandler implements AuthenticationFailureHandler {
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException, ServletException {
+
+        Gson gson = new Gson();
+        String jsonStr = gson.toJson(Map.of("error", "ERROR_LOGIN"));
+
+        response.setContentType("application/json"); // 200 전송으로 ERROR_LOGIN 전송
+        PrintWriter printWriter = response.getWriter();
+        printWriter.println(jsonStr);
+        printWriter.close();
+    }
+}

--- a/aptner/src/main/java/com/fastcampus/aptner/member/security/handler/APILoginSuccessHandler.java
+++ b/aptner/src/main/java/com/fastcampus/aptner/member/security/handler/APILoginSuccessHandler.java
@@ -1,0 +1,36 @@
+package com.fastcampus.aptner.member.security.handler;
+
+import com.fastcampus.aptner.member.dto.MemberDTO;
+import com.google.gson.Gson;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Map;
+
+@Log4j2
+public class APILoginSuccessHandler implements AuthenticationSuccessHandler {
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+
+        MemberDTO memberDTO = (MemberDTO) authentication.getPrincipal();
+
+        Map<String, Object> claims = memberDTO.getClaims();
+        claims.put("accessToken", "");
+        claims.put("refreshToken", "");
+
+        Gson gson = new Gson();
+        String jsonStr = gson.toJson(claims);// JSON 으로 생성으로 생성하기 때문에 컨트롤러로 뺄 필요가 없다.
+        response.setContentType("application/json; charset=UTF-8");
+
+        PrintWriter printWriter = response.getWriter();
+        printWriter.println(jsonStr);
+        printWriter.close();
+    }
+}

--- a/aptner/src/main/resources/application-test.yml
+++ b/aptner/src/main/resources/application-test.yml
@@ -7,7 +7,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
         show_sql: true

--- a/aptner/src/test/java/com/fastcampus/aptner/member/repository/MemberRepositoryTest.java
+++ b/aptner/src/test/java/com/fastcampus/aptner/member/repository/MemberRepositoryTest.java
@@ -23,21 +23,21 @@ class MemberRepositoryTest {
     public void InsertMember() {
         // given
         for (int i = 0; i < 10; i++) {
-            Member createdMember = Member.builder()
-                    .email("member" + i + "@gmail.com")
+            Member member = Member.builder()
+                    .email("user" + i + "@aaa.com")
                     .password(passwordEncoder.encode("1111"))
                     .nickname("USER" + i)
-                    .content(i + "동 반포자이")
+                    .content("USER content " + i)
                     .phone("010-1234-1234")
                     .socialLogin(false)
                     .build();
 
-            createdMember.addRole(MemberRole.USER);
+            member.addRole(MemberRole.USER);
 
-            if (i > 5) {createdMember.addRole(MemberRole.MANAGER);}
-            if (i > 8) {createdMember.addRole(MemberRole.ADMIN);}
+            if (i > 5) {member.addRole(MemberRole.MANAGER);}
+            if (i > 8) {member.addRole(MemberRole.ADMIN);}
 
-            memberRepository.save(createdMember);
+            memberRepository.save(member);
         }
         // expected
         Assertions.assertThat(memberRepository.count()).isEqualTo(10);


### PR DESCRIPTION
## Description

### 1. Build.gradle 의존성을 추가하기
1. spring security
- 테스트 환경에서 수행하기 위해 추가한다.

2. gson
 - JSON 데이터와 자바 객체 간의 직렬화 및 역직렬화를 처리한다.

3. querydsl
- 당장 사용은 안하는 의존성이지만, 미리 추가하여 querydsl 환경 세팅을 구성한다.

4. jjwt 0.11.5
- Json Web Token 방식으로 인증하기 위해 추가한다.

5. lombok 추가하기
- 테스트 환경에서 사용할 lombok 을 추가한다.

### 2. 세션 비활성화
SPA 방식에서는 Session 을 사용하지 않기 때문에 세션 생성 정책을 비활성화로 처리한다.

"/api/member/login" 으로 로그인을 시도할 때, 인증 성공 및 실패에 따라서 처리를 객체로 핸들링한다. 다양한 방식이 존재하는 것으로 알지만, 지금처럼 각 핸들러를 구현하는 방식이 스프링 시큐리티 구현의 정석이라고 한다.

### UserDetailsService 구현하기
회원 정보를 가져오기 위해 UserDetailsService 를 구현하는 CustomUserDetailsService 클래스.

- loadUserByUsername 메서드로
- UserDetails	회원의 정보를 불러와서
- UserDetails 로 반환한다.

원하는 형태로 CustomUserDetails를 세팅해준 후 리턴해주면 Spring Security에서는 해당 유저의 정보를 조회할 때에는 CustomUserDetails에 세팅된 값으로 조회를 한 후 로직을 처리해준다.

참고로, SecurityContextHolder에서 UserDetails 불러올 수 있다. 참고 코드는 다음과 같다.

```java
Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
UserDetails userDetails = (UserDetails)principal;

String username = userDetails.getUsername();
String password = userDetails.getPassword();
```

### 3. 인증 성공 및 실패 핸들러 구현하기
AuthenticationFailureHandler
- 인증에 실패하더라도, 200 status 를 넘겨주고 "ERROR_LOGIN" 메세지를 함께 JSON 데이터로 넘겨주는 방식을 채택했다. 빅테크 기업들이 사용하는 방식으로 유명하다고 하다.

APILoginSuccessHandler
- JWT 인증 방식을 사용할 것이다. 따라서 MemberDTO 에 JWT 처리를 위한 메서드인 getClaims() 에 의해 accessToken, refreshToken 그리고 회원 정보를 JWT 토큰에 포함해서 전달을 목표로 코드를 작성했다.

### 4. 인증 실패한 경우
![image](https://github.com/Final-Project-Team6/BE_Project/assets/131642334/e970ed48-4474-409c-a31b-0de9c581e738)


### 5. 인증 성공한 경우
![image](https://github.com/Final-Project-Team6/BE_Project/assets/131642334/8faf66a8-48f9-4915-98f6-3d7d9abeb1e1)


## Key Changes
Nothing

## To Reviewers
@cutegyuseok @NaSJ93 

This cloeses #16 