### PR TITLE
예외 수정 및 회원, JWT 컨트롤러 이름 변경 및 분리하기

### DIFF
--- a/aptner/src/main/java/com/fastcampus/aptner/apartment/controller/CreateApartmentController.java
+++ b/aptner/src/main/java/com/fastcampus/aptner/apartment/controller/CreateApartmentController.java
@@ -15,8 +15,8 @@ public class CreateApartmentController {
 
     private final CreateApartmentService apartmentService;
 
-    @PostMapping("/insert")
-    public ResponseEntity<?> saveApartment(@RequestBody CreateApartmentRequest request) {
+    @PostMapping("/create")
+    public ResponseEntity<?> createApartment(@RequestBody CreateApartmentRequest request) {
         apartmentService.createApartment(request);
         return new ResponseEntity<>(new HttpResponse<>(1, "아파트 등록 성공", null), HttpStatus.CREATED);
     }

--- a/aptner/src/main/java/com/fastcampus/aptner/apartment/service/CreateApartmentService.java
+++ b/aptner/src/main/java/com/fastcampus/aptner/apartment/service/CreateApartmentService.java
@@ -4,7 +4,5 @@ import com.fastcampus.aptner.apartment.dto.CreateApartmentRequest;
 
 
 public interface CreateApartmentService {
-
     void createApartment(CreateApartmentRequest request) ;
-
 }

--- a/aptner/src/main/java/com/fastcampus/aptner/global/config/SwaggerConfig.java
+++ b/aptner/src/main/java/com/fastcampus/aptner/global/config/SwaggerConfig.java
@@ -72,18 +72,50 @@ public class SwaggerConfig {
     }
 
     @Bean
-    public GroupedOpenApi memberGroup() {
-        return GroupedOpenApi.builder()
-                .group("회원")
-                .pathsToMatch("/api/members/**")
-                .build();
-    }
-
-    @Bean
     public GroupedOpenApi complaintGroup() {
         return GroupedOpenApi.builder()
                 .group("민원 게시판")
                 .pathsToMatch("/api/post/complaint/**")
+                .build();
+    }
+    
+    @Bean
+    public GroupedOpenApi loginGroup() {
+        return GroupedOpenApi.builder()
+                .group("로그인")
+                .pathsToMatch("/api/login/**")
+                .build();
+    }
+
+    @Bean
+    public GroupedOpenApi joinGroup() {
+        return GroupedOpenApi.builder()
+                .group("회원가입")
+                .pathsToMatch("/api/join/**")
+                .build();
+    }
+
+    @Bean
+    public GroupedOpenApi logoutGroup() {
+        return GroupedOpenApi.builder()
+                .group("로그아웃")
+                .pathsToMatch("/api/logout/**")
+                .build();
+    }
+
+    @Bean
+    public GroupedOpenApi refreshTokenGroup() {
+        return GroupedOpenApi.builder()
+                .group("리프레시 토큰 발행")
+                .pathsToMatch("/api/refresh-token/**")
+                .build();
+    }
+
+    @Bean
+    public GroupedOpenApi apartmentCreateGroup() {
+        return GroupedOpenApi.builder()
+                .group("아파트 추가")
+                .pathsToMatch("/api/apartment/**")
                 .build();
     }
 

--- a/aptner/src/main/java/com/fastcampus/aptner/global/handler/CustomExceptionHandler.java
+++ b/aptner/src/main/java/com/fastcampus/aptner/global/handler/CustomExceptionHandler.java
@@ -8,6 +8,7 @@ import org.springframework.dao.DataAccessException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice
@@ -16,6 +17,7 @@ public class CustomExceptionHandler {
     private final Logger log = LoggerFactory.getLogger(getClass());
 
     @ExceptionHandler(CustomAPIException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
     public ResponseEntity<?> apiException(CustomAPIException e) {
         log.error(e.getMessage());
         return new ResponseEntity<>(new HttpResponse<>(-1, e.getMessage(), null), HttpStatus.BAD_REQUEST);
@@ -49,6 +51,6 @@ public class CustomExceptionHandler {
     public ResponseEntity<?> handleDataAccessException(DataAccessException e) {
         log.error(e.getMessage());
         return new ResponseEntity<>(new HttpResponse<>(-1, e.getMessage(), null), HttpStatus.INTERNAL_SERVER_ERROR);
-
     }
+    
 }

--- a/aptner/src/main/java/com/fastcampus/aptner/global/handler/aop/CustomValidationAdvice.java
+++ b/aptner/src/main/java/com/fastcampus/aptner/global/handler/aop/CustomValidationAdvice.java
@@ -5,6 +5,8 @@ import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Pointcut;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.MessageSource;
 import org.springframework.stereotype.Component;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
@@ -15,6 +17,7 @@ import java.util.Map;
 @Component
 @Aspect
 public class CustomValidationAdvice {
+    
     // post, put (body) 어드바이스 작성하기
     @Pointcut("@annotation(org.springframework.web.bind.annotation.PostMapping)")
     public void postMapping() {}
@@ -27,9 +30,7 @@ public class CustomValidationAdvice {
     public Object validationAdvice(ProceedingJoinPoint proceedingJoinPoint) throws Throwable {
         Object[] args = proceedingJoinPoint.getArgs(); // joinPoint 의 매개변수
         for (Object arg : args) {
-            if (arg instanceof BindingResult) {
-                BindingResult bindingResult = (BindingResult) arg;
-
+            if (arg instanceof BindingResult bindingResult) {
                 if (bindingResult.hasErrors()) {
                     Map<String, String> errorMap = new HashMap<>();
 

--- a/aptner/src/main/java/com/fastcampus/aptner/global/handler/aop/CustomValidationAdvice.java
+++ b/aptner/src/main/java/com/fastcampus/aptner/global/handler/aop/CustomValidationAdvice.java
@@ -17,7 +17,7 @@ import java.util.Map;
 @Component
 @Aspect
 public class CustomValidationAdvice {
-    
+
     // post, put (body) 어드바이스 작성하기
     @Pointcut("@annotation(org.springframework.web.bind.annotation.PostMapping)")
     public void postMapping() {}

--- a/aptner/src/main/java/com/fastcampus/aptner/jwt/controller/RefreshTokenController.java
+++ b/aptner/src/main/java/com/fastcampus/aptner/jwt/controller/RefreshTokenController.java
@@ -1,0 +1,67 @@
+package com.fastcampus.aptner.jwt.controller;
+
+import com.fastcampus.aptner.apartment.service.FindApartmentService;
+import com.fastcampus.aptner.jwt.domain.TokenStorage;
+import com.fastcampus.aptner.jwt.dto.RefreshTokenRequest;
+import com.fastcampus.aptner.jwt.service.RefreshTokenService;
+import com.fastcampus.aptner.jwt.util.JwtTokenizer;
+import com.fastcampus.aptner.member.domain.Member;
+import com.fastcampus.aptner.member.dto.HttpResponse;
+import com.fastcampus.aptner.member.dto.reqeust.LoginMemberResponse;
+import com.fastcampus.aptner.member.service.FindMemberRoleServiceImpl;
+import com.fastcampus.aptner.member.service.loginMemberService;
+import io.jsonwebtoken.Claims;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/refresh-token")
+@RestController
+public class RefreshTokenController {
+
+    private final JwtTokenizer jwtTokenizer;
+    private final loginMemberService memberService;
+    private final RefreshTokenService refreshTokenService;
+    private final FindMemberRoleServiceImpl memberRoleService;
+    private final FindApartmentService apartmentService;
+
+    /*
+        1. 전달받은 유저의 아이디로 유저가 존재하는지 확인한다.
+        2. RefreshToken 이 유효한지 체크한다.
+        3. AccessToken 을 발급하여 기존 RefreshToken 과 함께 응답한다.
+    */
+    @PostMapping("/publish")
+    public ResponseEntity<?> requestRefresh(@RequestBody RefreshTokenRequest refreshTokenDto) {
+        TokenStorage refreshToken = refreshTokenService.findRefreshToken(refreshTokenDto.getRefreshToken()).orElseThrow(() -> new IllegalArgumentException("Refresh token not found"));
+        Claims claims = jwtTokenizer.parseRefreshToken(refreshToken.getRefreshToken());
+
+        Long memberId = Long.valueOf((Integer) claims.get("memberId"));
+
+        // TODO: 회원 정보  예외 처리 수정하기.
+        Member member = memberService.findMemberById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("Member not found"));
+
+        String username = claims.getSubject();
+        Long apartmentId = (Long) claims.get("apartmentId");
+
+        // 회원 아이디, 아파트로 권한 찾기
+        String apartmentName = apartmentService.findApartmentById(apartmentId).getName();
+        String memberRole = memberRoleService.getMemberRole(member.getMemberId(), apartmentId).toString();
+
+        String accessToken = jwtTokenizer.createAccessToken(memberId, username, memberRole, apartmentName, apartmentId);
+
+        LoginMemberResponse loginResponse = LoginMemberResponse.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshTokenDto.getRefreshToken())
+                .memberId(member.getMemberId())
+                .nickname(member.getUsername())
+                .build();
+
+        return new ResponseEntity<>(new HttpResponse<>(1, "리프레시 토큰이 재발급 되었습니다.", loginResponse), HttpStatus.OK);
+    }
+}

--- a/aptner/src/main/java/com/fastcampus/aptner/jwt/util/isLoginArgumentResolver.java
+++ b/aptner/src/main/java/com/fastcampus/aptner/jwt/util/isLoginArgumentResolver.java
@@ -1,7 +1,7 @@
 package com.fastcampus.aptner.jwt.util;
 
 import com.fastcampus.aptner.jwt.token.JwtAuthenticationToken;
-import com.fastcampus.aptner.member.dto.reqeust.SignInMemberRequest;
+import com.fastcampus.aptner.member.dto.reqeust.LoginMemberRequest;
 import org.springframework.core.MethodParameter;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
@@ -19,7 +19,7 @@ public class isLoginArgumentResolver implements HandlerMethodArgumentResolver {
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
         return parameter.getParameterAnnotation(isLogin.class) != null
-                && parameter.getParameterType() == SignInMemberRequest.class;
+                && parameter.getParameterType() == LoginMemberRequest.class;
     }
 
     @Override

--- a/aptner/src/main/java/com/fastcampus/aptner/member/controller/JoinMemberController.java
+++ b/aptner/src/main/java/com/fastcampus/aptner/member/controller/JoinMemberController.java
@@ -1,23 +1,25 @@
 package com.fastcampus.aptner.member.controller;
 
 import com.fastcampus.aptner.member.dto.HttpResponse;
-import com.fastcampus.aptner.member.dto.reqeust.SignUpMemberRequest;
-import com.fastcampus.aptner.member.service.SignUpMemberService;
+import com.fastcampus.aptner.member.dto.reqeust.JoinMemberRequest;
+import com.fastcampus.aptner.member.service.JoinMemberService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
-@RequestMapping("/api/members")
+@RequestMapping("/api/join")
 @RestController
-public class SignUpMemberController {
+public class JoinMemberController {
 
-    private final SignUpMemberService memberService;
+    private final JoinMemberService memberService;
 
-    @PostMapping("/signup")
-    public ResponseEntity<?> signUpMember(@RequestBody SignUpMemberRequest request) {
-        memberService.signUpMember(request);
+    @PostMapping("/member")
+    public ResponseEntity<?> joinMember(@RequestBody @Valid JoinMemberRequest request, BindingResult result) {
+        memberService.joinMember(request);
         return new ResponseEntity<>(new HttpResponse<>(1, "회원 가입에 성공했습니다.", null), HttpStatus.CREATED);
     }
 

--- a/aptner/src/main/java/com/fastcampus/aptner/member/controller/LoginMemberController.java
+++ b/aptner/src/main/java/com/fastcampus/aptner/member/controller/LoginMemberController.java
@@ -2,16 +2,14 @@ package com.fastcampus.aptner.member.controller;
 
 import com.fastcampus.aptner.apartment.service.FindApartmentService;
 import com.fastcampus.aptner.jwt.domain.TokenStorage;
-import com.fastcampus.aptner.jwt.dto.RefreshTokenRequest;
 import com.fastcampus.aptner.jwt.service.RefreshTokenService;
 import com.fastcampus.aptner.jwt.util.JwtTokenizer;
 import com.fastcampus.aptner.member.domain.Member;
 import com.fastcampus.aptner.member.dto.HttpResponse;
-import com.fastcampus.aptner.member.dto.reqeust.SignInMemberRequest;
-import com.fastcampus.aptner.member.dto.reqeust.SignInMemberResponse;
+import com.fastcampus.aptner.member.dto.reqeust.LoginMemberRequest;
+import com.fastcampus.aptner.member.dto.reqeust.LoginMemberResponse;
 import com.fastcampus.aptner.member.service.FindMemberRoleServiceImpl;
-import com.fastcampus.aptner.member.service.SignInMemberService;
-import io.jsonwebtoken.Claims;
+import com.fastcampus.aptner.member.service.loginMemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -20,20 +18,20 @@ import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
-@RequestMapping("/api/members")
+@RequestMapping("/api/login")
 @RestController
-public class SignInMemberController {
+public class LoginMemberController {
 
     private final JwtTokenizer jwtTokenizer;
-    private final SignInMemberService memberService;
+    private final loginMemberService memberService;
     private final RefreshTokenService refreshTokenService;
     private final FindMemberRoleServiceImpl memberRoleService;
     private final FindApartmentService apartmentService;
 
     private final BCryptPasswordEncoder bCryptPasswordEncoder;
 
-    @PostMapping("/login")
-    public ResponseEntity<?> login(@RequestBody SignInMemberRequest request, BindingResult bindingResult) {
+    @PostMapping("/member")
+    public ResponseEntity<?> signIn(@RequestBody LoginMemberRequest request, BindingResult bindingResult) {
         if (bindingResult.hasErrors()) {
             return new ResponseEntity<>(new HttpResponse<>(-1, "잘못된 요청 입니다.", null), HttpStatus.BAD_REQUEST);
         }
@@ -52,7 +50,7 @@ public class SignInMemberController {
         String accessToken = jwtTokenizer.createAccessToken(member.getMemberId(), member.getUsername(), memberRole, request.getApartmentName(), apartmentId);
         String refreshToken = jwtTokenizer.createRefreshToken(member.getMemberId(), member.getUsername(), memberRole, apartmentId);
 
-        // RefreshToken 을 MySQL 에 저장. -> Redis 으로 저장 필요하다.
+        // TODO: RefreshToken 을 MySQL 에 저장. -> Redis 으로 저장 필요하다.
         TokenStorage refreshTokenEntity = TokenStorage.builder()
                 .refreshToken(refreshToken)
                 .memberId(member.getMemberId())
@@ -60,7 +58,7 @@ public class SignInMemberController {
 
         refreshTokenService.addRefreshToken(refreshTokenEntity);
 
-        SignInMemberResponse loginResponse = SignInMemberResponse.builder()
+        LoginMemberResponse loginResponse = LoginMemberResponse.builder()
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)
                 .memberId(member.getMemberId())
@@ -69,47 +67,4 @@ public class SignInMemberController {
 
         return new ResponseEntity<>(new HttpResponse<>(1, "로그인 성공 입니다.", loginResponse), HttpStatus.OK);
     }
-
-    @DeleteMapping("/logout")
-    public ResponseEntity<?> logout(@RequestBody RefreshTokenRequest refreshTokenRequest) {
-        refreshTokenService.deleteRefreshToken(refreshTokenRequest.getRefreshToken());
-        return new ResponseEntity<>(new HttpResponse<>(1, "로그아웃 되었습니다.", null), HttpStatus.OK);
-    }
-
-    /*
-        1. 전달받은 유저의 아이디로 유저가 존재하는지 확인한다.
-        2. RefreshToken 이 유효한지 체크한다.
-        3. AccessToken 을 발급하여 기존 RefreshToken 과 함께 응답한다.
- */
-    @PostMapping("/refreshToken")
-    public ResponseEntity<?> requestRefresh(@RequestBody RefreshTokenRequest refreshTokenDto) {
-        TokenStorage refreshToken = refreshTokenService.findRefreshToken(refreshTokenDto.getRefreshToken()).orElseThrow(() -> new IllegalArgumentException("Refresh token not found"));
-        Claims claims = jwtTokenizer.parseRefreshToken(refreshToken.getRefreshToken());
-
-        Long memberId = Long.valueOf((Integer) claims.get("memberId"));
-
-        // TODO: 회원 정보  예외 처리 수정하기.
-        Member member = memberService.findMemberById(memberId)
-                .orElseThrow(() -> new IllegalArgumentException("Member not found"));
-
-        String username = claims.getSubject();
-        Long apartmentId = (Long) claims.get("apartmentId");
-
-        // 회원 아이디, 아파트로 권한 찾기
-        String apartmentName = apartmentService.findApartmentById(apartmentId).getName();
-        String memberRole = memberRoleService.getMemberRole(member.getMemberId(), apartmentId).toString();
-
-        String accessToken = jwtTokenizer.createAccessToken(memberId, username, memberRole, apartmentName, apartmentId);
-
-        SignInMemberResponse loginResponse = SignInMemberResponse.builder()
-                .accessToken(accessToken)
-                .refreshToken(refreshTokenDto.getRefreshToken())
-                .memberId(member.getMemberId())
-                .nickname(member.getUsername())
-                .build();
-
-        return new ResponseEntity<>(new HttpResponse<>(1, "리프레시 토큰이 재발급 되었습니다.", loginResponse), HttpStatus.OK);
-    }
-
-
 }

--- a/aptner/src/main/java/com/fastcampus/aptner/member/controller/LogoutMemberController.java
+++ b/aptner/src/main/java/com/fastcampus/aptner/member/controller/LogoutMemberController.java
@@ -1,0 +1,27 @@
+package com.fastcampus.aptner.member.controller;
+
+import com.fastcampus.aptner.jwt.dto.RefreshTokenRequest;
+import com.fastcampus.aptner.jwt.service.RefreshTokenService;
+import com.fastcampus.aptner.member.dto.HttpResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/logout")
+@RestController
+public class LogoutMemberController {
+
+    private final RefreshTokenService refreshTokenService;
+
+    @DeleteMapping("/member")
+    public ResponseEntity<?> logout(@RequestBody RefreshTokenRequest refreshTokenRequest) {
+        refreshTokenService.deleteRefreshToken(refreshTokenRequest.getRefreshToken());
+        return new ResponseEntity<>(new HttpResponse<>(1, "로그아웃 되었습니다.", null), HttpStatus.OK);
+    }
+
+}

--- a/aptner/src/main/java/com/fastcampus/aptner/member/domain/MemberRole.java
+++ b/aptner/src/main/java/com/fastcampus/aptner/member/domain/MemberRole.java
@@ -7,13 +7,13 @@ import lombok.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @ToString
-@Table(name = "memberRole")
+@Table(name = "member_role")
 @Entity
 public class MemberRole {
     
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "memberRole_id", nullable = false, updatable = false)
+    @Column(name = "member_role_id", nullable = false, updatable = false)
     private Long memberRoleId;
 
     @Enumerated(EnumType.STRING)

--- a/aptner/src/main/java/com/fastcampus/aptner/member/dto/HttpResponse.java
+++ b/aptner/src/main/java/com/fastcampus/aptner/member/dto/HttpResponse.java
@@ -2,6 +2,7 @@ package com.fastcampus.aptner.member.dto;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import lombok.Setter;
 
 @RequiredArgsConstructor
 @Getter

--- a/aptner/src/main/java/com/fastcampus/aptner/member/dto/reqeust/JoinMemberRequest.java
+++ b/aptner/src/main/java/com/fastcampus/aptner/member/dto/reqeust/JoinMemberRequest.java
@@ -7,12 +7,10 @@ import lombok.Builder;
 import lombok.Getter;
 
 @Getter
-public class SignUpMemberRequest {
+public class JoinMemberRequest {
 
-    @NotBlank(message = "동의여부: 서비스 이용약관 동의는 필수입니다.")
     private final boolean termsService;
 
-    @NotBlank(message = "동의여부: 개인정보 수집 동의는 필수입니다.")
     private final boolean privateInformationCollection;
 
     private final boolean snsMarketingInformationReceive; // SNS 마케팅 정보 수신 동의는 선택입니다.
@@ -73,7 +71,7 @@ public class SignUpMemberRequest {
 
 
     @Builder
-    public SignUpMemberRequest(boolean termsService, boolean privateInformationCollection, boolean snsMarketingInformationReceive, String fullName, String birthFirst, String gender, String phoneCarrier, String phone, String username, String password, String nickname, String dong, String ho, String apartmentName) {
+    public JoinMemberRequest(boolean termsService, boolean privateInformationCollection, boolean snsMarketingInformationReceive, String fullName, String birthFirst, String gender, String phoneCarrier, String phone, String username, String password, String nickname, String dong, String ho, String apartmentName) {
         this.termsService = termsService;
         this.privateInformationCollection = privateInformationCollection;
         this.snsMarketingInformationReceive = snsMarketingInformationReceive;

--- a/aptner/src/main/java/com/fastcampus/aptner/member/dto/reqeust/LoginMemberRequest.java
+++ b/aptner/src/main/java/com/fastcampus/aptner/member/dto/reqeust/LoginMemberRequest.java
@@ -9,7 +9,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class SignInMemberRequest {
+public class LoginMemberRequest {
 
     private String username;
     private String password;

--- a/aptner/src/main/java/com/fastcampus/aptner/member/dto/reqeust/LoginMemberResponse.java
+++ b/aptner/src/main/java/com/fastcampus/aptner/member/dto/reqeust/LoginMemberResponse.java
@@ -9,7 +9,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class SignInMemberResponse {
+public class LoginMemberResponse {
     private String accessToken;
     private String refreshToken;
 

--- a/aptner/src/main/java/com/fastcampus/aptner/member/service/JoinMemberService.java
+++ b/aptner/src/main/java/com/fastcampus/aptner/member/service/JoinMemberService.java
@@ -1,12 +1,12 @@
 package com.fastcampus.aptner.member.service;
 
 
-import com.fastcampus.aptner.member.dto.reqeust.SignUpMemberRequest;
+import com.fastcampus.aptner.member.dto.reqeust.JoinMemberRequest;
 
-public interface SignUpMemberService {
+public interface JoinMemberService {
     void checkMemberPhoneDuplication(String phone);
     void checkMemberNickNameDuplication(String nickname);
     void checkMemberUsernameDuplication(String username);
-    void signUpMember(SignUpMemberRequest request);
+    void joinMember(JoinMemberRequest request);
 
 }

--- a/aptner/src/main/java/com/fastcampus/aptner/member/service/JoinMemberServiceImpl.java
+++ b/aptner/src/main/java/com/fastcampus/aptner/member/service/JoinMemberServiceImpl.java
@@ -6,7 +6,7 @@ import com.fastcampus.aptner.apartment.repository.ApartmentRepository;
 import com.fastcampus.aptner.apartment.repository.HomeRepository;
 import com.fastcampus.aptner.global.handler.exception.CustomDuplicationKeyException;
 import com.fastcampus.aptner.member.domain.*;
-import com.fastcampus.aptner.member.dto.reqeust.SignUpMemberRequest;
+import com.fastcampus.aptner.member.dto.reqeust.JoinMemberRequest;
 import com.fastcampus.aptner.member.repository.MemberRepository;
 import com.fastcampus.aptner.member.repository.MemberRoleRepository;
 import com.fastcampus.aptner.member.repository.SubscriptionRepository;
@@ -21,7 +21,7 @@ import org.springframework.stereotype.Service;
 @FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
 @RequiredArgsConstructor
 @Service
-public class SignUpMemberServiceImpl implements SignUpMemberService {
+public class JoinMemberServiceImpl implements JoinMemberService {
 
     private final MemberRepository memberRepository;
     private final HomeRepository homeRepository;
@@ -52,9 +52,11 @@ public class SignUpMemberServiceImpl implements SignUpMemberService {
         }
     }
 
+
+
     // TODO: 로직 분리가 가능해 보인다. 리팩토링 고민해보자.
     @Transactional
-    public void signUpMember(SignUpMemberRequest request) {
+    public void joinMember(JoinMemberRequest request) {
 
         checkMemberPhoneDuplication(request.getPhone());
         checkMemberNickNameDuplication(request.getNickname());

--- a/aptner/src/main/java/com/fastcampus/aptner/member/service/loginMemberService.java
+++ b/aptner/src/main/java/com/fastcampus/aptner/member/service/loginMemberService.java
@@ -4,7 +4,7 @@ import com.fastcampus.aptner.member.domain.Member;
 
 import java.util.Optional;
 
-public interface SignInMemberService {
+public interface loginMemberService {
 
     Member findByUsername(String username);
     Optional<Member> findMemberById(Long memberId);

--- a/aptner/src/main/java/com/fastcampus/aptner/member/service/loginMemberServiceImpl.java
+++ b/aptner/src/main/java/com/fastcampus/aptner/member/service/loginMemberServiceImpl.java
@@ -11,7 +11,7 @@ import java.util.Optional;
 
 @RequiredArgsConstructor
 @Service
-public class SignInMemberServiceImpl implements SignInMemberService {
+public class loginMemberServiceImpl implements loginMemberService {
 
     private final MemberRepository memberRepository;
 


### PR DESCRIPTION
## Description
스프링 IoC 컨테이너에 등록되어 있는 커스텀 AOP 는 지금까지 스프링에서 에러 메시지를 생성하고 응답하도록 작성한 방식을 변경했다. @pattern message 속성값을 응답값으로 반환할 수 있도록 하자.

회원, JWT 컨트롤러를 분리하고 각 컨트롤러는 의미에 알맞게 다시 수정한다.
명확한 의미를 전달하고자 Login, Logout 으로 변경하고 경로도 변경했다.

## To Reviewers
@cutegyuseok @NaSJ93 

This closes #54 
This closes #55 