### PR TITLE
리프레시 토큰 재발급 에러 발생 이슈 해결하기

### DIFF
--- a/aptner/build.gradle
+++ b/aptner/build.gradle
@@ -59,8 +59,11 @@ dependencies {
 	testCompileOnly 'org.projectlombok:lombok'
 	testAnnotationProcessor 'org.projectlombok:lombok'
 
-	//7. aws cloud
+	// 7. aws cloud
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
+	// 8. 레디스 추가하기
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
 }
 

--- a/aptner/src/main/java/com/fastcampus/aptner/apartment/controller/FindApartmentController.java
+++ b/aptner/src/main/java/com/fastcampus/aptner/apartment/controller/FindApartmentController.java
@@ -22,7 +22,7 @@ public class FindApartmentController {
 
     @Operation(
             summary = "아파트 이름으로 아파트 조회 API\n\n",
-            description = "Schema -? apartmentName 아파트 이름"
+            description = "Schema -> apartmentName: 아파트 이름"
     )
     @GetMapping("/search")
     public ResponseEntity<?> findByApartmentName(@RequestBody FindApartmentRequest request) {

--- a/aptner/src/main/java/com/fastcampus/aptner/global/handler/CustomExceptionHandler.java
+++ b/aptner/src/main/java/com/fastcampus/aptner/global/handler/CustomExceptionHandler.java
@@ -24,30 +24,35 @@ public class CustomExceptionHandler {
     }
 
     @ExceptionHandler(CustomForbiddenException.class)
+    @ResponseStatus(HttpStatus.FORBIDDEN)
     public ResponseEntity<?> forbiddenException(CustomForbiddenException e) {
         log.error(e.getMessage());
         return new ResponseEntity<>(new HttpResponse<>(-1, e.getMessage(), null), HttpStatus.FORBIDDEN);
     }
 
     @ExceptionHandler(CustomValidationException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
     public ResponseEntity<?> validationApiException(CustomValidationException e) {
         log.error(e.getMessage());
         return new ResponseEntity<>(new HttpResponse<>(-1, e.getMessage(), e.getErrorMap()), HttpStatus.BAD_REQUEST);
     }
 
     @ExceptionHandler(CustomDataNotFoundException.class)
+    @ResponseStatus(HttpStatus.CONFLICT)
     public ResponseEntity<?> handleDuplicateKeyException(CustomDataNotFoundException e) {
         log.error(e.getMessage());
         return new ResponseEntity<>(new HttpResponse<>(-1, e.getMessage(), null), HttpStatus.CONFLICT);
     }
 
     @ExceptionHandler(CustomDuplicationKeyException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
     public ResponseEntity<?> handleNotFoundException(CustomDuplicationKeyException e) {
         log.error(e.getMessage());
         return new ResponseEntity<>(new HttpResponse<>(-1, e.getMessage(), null), HttpStatus.NOT_FOUND);
     }
 
     @ExceptionHandler(DataAccessException.class)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     public ResponseEntity<?> handleDataAccessException(DataAccessException e) {
         log.error(e.getMessage());
         return new ResponseEntity<>(new HttpResponse<>(-1, e.getMessage(), null), HttpStatus.INTERNAL_SERVER_ERROR);

--- a/aptner/src/main/java/com/fastcampus/aptner/jwt/controller/RefreshTokenController.java
+++ b/aptner/src/main/java/com/fastcampus/aptner/jwt/controller/RefreshTokenController.java
@@ -4,14 +4,16 @@ import com.fastcampus.aptner.apartment.service.FindApartmentService;
 import com.fastcampus.aptner.global.handler.exception.CustomAPIException;
 import com.fastcampus.aptner.jwt.domain.TokenStorage;
 import com.fastcampus.aptner.jwt.dto.RefreshTokenRequest;
+import com.fastcampus.aptner.jwt.dto.TokenStorageDto;
 import com.fastcampus.aptner.jwt.service.RefreshTokenService;
 import com.fastcampus.aptner.jwt.util.JwtTokenizer;
 import com.fastcampus.aptner.member.domain.Member;
 import com.fastcampus.aptner.member.dto.HttpResponse;
-import com.fastcampus.aptner.member.dto.reqeust.LoginMemberResponse;
+import com.fastcampus.aptner.member.dto.response.LoginMemberResponse;
 import com.fastcampus.aptner.member.service.FindMemberRoleServiceImpl;
 import com.fastcampus.aptner.member.service.loginMemberService;
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -39,6 +41,7 @@ public class RefreshTokenController {
         2. RefreshToken 이 유효한지 체크한다.
         3. AccessToken 을 발급하여 기존 RefreshToken 과 함께 응답한다.
     */
+
     @Operation(
             summary = "JWT 리프레시 토큰 발행 API",
             description = "새로운 액세스 토큰, 리프레시 토큰을 발행한다. \n\n +" +
@@ -48,28 +51,44 @@ public class RefreshTokenController {
     )
     @PostMapping("/publish")
     public ResponseEntity<?> requestRefresh(@RequestBody RefreshTokenRequest request) {
-        TokenStorage refreshToken = refreshTokenService.findRefreshToken(request.getRefreshToken()).orElseThrow(() -> new IllegalArgumentException("Refresh token not found"));
-        Claims claims = jwtTokenizer.parseRefreshToken(refreshToken.getRefreshToken());
+        TokenStorage refreshToken = refreshTokenService.findRefreshToken(request.getRefreshToken())
+                .orElseThrow(() -> new IllegalArgumentException("리프레시 토큰을 찾을 수 없습니다."));
 
-        Long memberId = Long.valueOf((Integer) claims.get("memberId"));
+        Claims claims;
+        try {
+            claims = jwtTokenizer.parseRefreshToken(refreshToken.getRefreshToken());
+        } catch (ExpiredJwtException e) {
+            return new ResponseEntity<>(new HttpResponse<>(-1, "리프레시 토큰이 만료되었습니다.", null), HttpStatus.UNAUTHORIZED);
+        } catch (Exception e) {
+            return new ResponseEntity<>(new HttpResponse<>(-1, "유효하지 않은 리프레시 토큰입니다.", null), HttpStatus.BAD_REQUEST);
+        }
 
-        // TODO: 회원 정보  예외 처리 수정하기.
+        Long memberId = claims.get("memberId", Long.class); // 수정
+
         Member member = memberService.findMemberById(memberId)
                 .orElseThrow(() -> new CustomAPIException("회원이 존재하지 않습니다."));
 
         String username = claims.getSubject();
-        Long apartmentId = (Long) claims.get("apartmentId");
+        Long apartmentId = claims.get("apartmentId", Long.class); // 수정
 
-        // 회원 아이디, 아파트로 권한 찾기
         String apartmentName = apartmentService.findApartmentById(apartmentId).getName();
-        String memberRole = memberRoleService.getMemberRole(member.getMemberId(), apartmentId).toString();
+        String memberRole = memberRoleService.getMemberRole(memberId, apartmentId).toString(); // 수정
 
-        String accessToken = jwtTokenizer.createAccessToken(memberId, username, memberRole, apartmentName, apartmentId);
+        String newAccessToken = jwtTokenizer.createAccessToken(memberId, username, memberRole, apartmentName, apartmentId);
+        String newRefreshToken = jwtTokenizer.createRefreshToken(memberId, username, memberRole, apartmentName, apartmentId);
+
+        TokenStorageDto tokenStorageDto = TokenStorageDto.builder()
+                .memberId(memberId)
+                .refreshToken(newRefreshToken)
+                .build();
+
+        // 새로운 리프레시 토큰 저장 및 이전 토큰 무효화
+        refreshTokenService.saveNewRefreshToken(tokenStorageDto);
 
         LoginMemberResponse loginResponse = LoginMemberResponse.builder()
-                .accessToken(accessToken)
-                .refreshToken(request.getRefreshToken())
-                .memberId(member.getMemberId())
+                .accessToken(newAccessToken)
+                .refreshToken(newRefreshToken)
+                .memberId(memberId)
                 .nickname(member.getUsername())
                 .build();
 

--- a/aptner/src/main/java/com/fastcampus/aptner/jwt/domain/TokenStorage.java
+++ b/aptner/src/main/java/com/fastcampus/aptner/jwt/domain/TokenStorage.java
@@ -5,6 +5,8 @@ import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
 
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
 
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -19,6 +21,7 @@ public class TokenStorage {
     @Column(name = "tokenStorage_id", nullable = false, updatable = false)
     private Long tokenStorageId; // 토큰 id
 
+    @Column(length = 512)
     private String refreshToken; // 리프레시 토큰 번호
 
     @CreatedDate
@@ -30,6 +33,6 @@ public class TokenStorage {
     public TokenStorage(String refreshToken, Long memberId) {
         this.refreshToken = refreshToken;
         this.memberId = memberId;
-        this.createdAt = createdAt; // TODO: 날짜 넣기
+        this.createdAt = LocalDateTime.now().truncatedTo(ChronoUnit.SECONDS);
     }
 }

--- a/aptner/src/main/java/com/fastcampus/aptner/jwt/dto/TokenStorageDto.java
+++ b/aptner/src/main/java/com/fastcampus/aptner/jwt/dto/TokenStorageDto.java
@@ -1,0 +1,15 @@
+package com.fastcampus.aptner.jwt.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class TokenStorageDto {
+    private String refreshToken;
+    private Long memberId;
+}

--- a/aptner/src/main/java/com/fastcampus/aptner/jwt/repository/RefreshTokenRepository.java
+++ b/aptner/src/main/java/com/fastcampus/aptner/jwt/repository/RefreshTokenRepository.java
@@ -7,4 +7,5 @@ import java.util.Optional;
 
 public interface RefreshTokenRepository extends JpaRepository<TokenStorage, Long> {
     Optional<TokenStorage> findByRefreshToken(String value);
+    Optional<TokenStorage> findByMemberId(Long memberId);
 }

--- a/aptner/src/main/java/com/fastcampus/aptner/jwt/service/RefreshTokenService.java
+++ b/aptner/src/main/java/com/fastcampus/aptner/jwt/service/RefreshTokenService.java
@@ -1,6 +1,7 @@
 package com.fastcampus.aptner.jwt.service;
 
 import com.fastcampus.aptner.jwt.domain.TokenStorage;
+import com.fastcampus.aptner.jwt.dto.TokenStorageDto;
 import com.fastcampus.aptner.jwt.repository.RefreshTokenRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -26,5 +27,19 @@ public class RefreshTokenService {
     @Transactional(readOnly = true)
     public Optional<TokenStorage> findRefreshToken(String refreshToken) {
         return refreshTokenRepository.findByRefreshToken(refreshToken);
+    }
+
+    @Transactional
+    public void saveNewRefreshToken(TokenStorageDto tokenStorageDto) {
+        // 기존 리프레시 토큰 삭제
+        refreshTokenRepository.findByMemberId(tokenStorageDto.getMemberId()).ifPresent(refreshTokenRepository::delete);
+
+        // 새로운 리프레시 토큰 저장
+        TokenStorage tokenStorage = TokenStorage.builder()
+                .refreshToken(tokenStorageDto.getRefreshToken())
+                .memberId(tokenStorageDto.getMemberId())
+                .build();
+
+        refreshTokenRepository.save(tokenStorage);
     }
 }

--- a/aptner/src/main/java/com/fastcampus/aptner/jwt/util/JwtTokenizer.java
+++ b/aptner/src/main/java/com/fastcampus/aptner/jwt/util/JwtTokenizer.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Component;
 import java.nio.charset.StandardCharsets;
 import java.security.Key;
 import java.util.Date;
+import java.util.UUID;
 
 @Slf4j
 @Component
@@ -47,8 +48,8 @@ public class JwtTokenizer {
 
         return Jwts.builder()
                 .setClaims(claims)
-                .setIssuedAt(new Date())
-                .setExpiration(new Date(new Date().getTime() + ACCESS_TOKEN_EXPIRE_COUNT))
+                .setIssuedAt(new Date(System.currentTimeMillis()))
+                .setExpiration(new Date(System.currentTimeMillis() + ACCESS_TOKEN_EXPIRE_COUNT))
                 .signWith(getSigningKey(accessSecret))
                 .compact();
     }
@@ -59,18 +60,24 @@ public class JwtTokenizer {
     public String createRefreshToken(Long memberId,
                                      String username,
                                      String roleName,
+                                     String apartmentName,
                                      Long apartmentId) {
         Claims claims = Jwts.claims().setSubject(username);
 
         claims.put("roleName", roleName);
         claims.put("memberId", memberId);
         claims.put("username", username);
+        claims.put("apartmentName", apartmentName);
         claims.put("apartmentId", apartmentId);
 
+        // 고유한 값을 생성하여 리프레시 토큰의 식별자로 사용
+        String uniqueId = UUID.randomUUID().toString();
+
         return Jwts.builder()
+                .setId(uniqueId)
                 .setClaims(claims)
-                .setIssuedAt(new Date())
-                .setExpiration(new Date(new Date().getTime() + REFRESH_TOKEN_EXPIRE_COUNT))
+                .setIssuedAt(new Date(System.currentTimeMillis()))
+                .setExpiration(new Date(System.currentTimeMillis() + REFRESH_TOKEN_EXPIRE_COUNT))
                 .signWith(getSigningKey(refreshSecret))
                 .compact();
     }
@@ -83,14 +90,14 @@ public class JwtTokenizer {
         String[] tokenArr = token.split(" ");
         token = tokenArr[1];
         Claims claims = parseToken(token, accessSecret);
-        return Long.valueOf((Integer)claims.get("memberId"));
+        return claims.get("memberId", Long.class);
     }
 
     public String getMemberRoleFromToken(String token) {
         String[] tokenArr = token.split(" ");
         token = tokenArr[1];
         Claims claims = parseToken(token, accessSecret);
-        return String.valueOf(claims.get("roleName"));
+        return claims.get("roleName", String.class);
     }
 
 

--- a/aptner/src/main/java/com/fastcampus/aptner/member/controller/LoginMemberController.java
+++ b/aptner/src/main/java/com/fastcampus/aptner/member/controller/LoginMemberController.java
@@ -7,7 +7,7 @@ import com.fastcampus.aptner.jwt.util.JwtTokenizer;
 import com.fastcampus.aptner.member.domain.Member;
 import com.fastcampus.aptner.member.dto.HttpResponse;
 import com.fastcampus.aptner.member.dto.reqeust.LoginMemberRequest;
-import com.fastcampus.aptner.member.dto.reqeust.LoginMemberResponse;
+import com.fastcampus.aptner.member.dto.response.LoginMemberResponse;
 import com.fastcampus.aptner.member.service.FindMemberRoleServiceImpl;
 import com.fastcampus.aptner.member.service.loginMemberService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -57,7 +57,7 @@ public class LoginMemberController {
 
         // JWT 토큰 생성하는 시점.
         String accessToken = jwtTokenizer.createAccessToken(member.getMemberId(), member.getUsername(), memberRole, request.getApartmentName(), apartmentId);
-        String refreshToken = jwtTokenizer.createRefreshToken(member.getMemberId(), member.getUsername(), memberRole, apartmentId);
+        String refreshToken = jwtTokenizer.createRefreshToken(member.getMemberId(), member.getUsername(), memberRole, request.getApartmentName(), apartmentId);
 
         // TODO: RefreshToken 을 MySQL 에 저장. -> Redis 으로 저장 필요하다.
         TokenStorage refreshTokenEntity = TokenStorage.builder()

--- a/aptner/src/main/java/com/fastcampus/aptner/member/domain/Subscription.java
+++ b/aptner/src/main/java/com/fastcampus/aptner/member/domain/Subscription.java
@@ -23,13 +23,13 @@ public class Subscription {
     private Member memberId;
 
     @Column(name = "terms_service")
-    private boolean termsService;
+    private Boolean termsService;
 
     @Column(name = "private_information_collection")
-    private boolean privateInformationCollection;
+    private Boolean privateInformationCollection;
 
     @Column(name = "sns_marketing_information_receivce")
-    private boolean snsMarketingInformationReceive;
+    private Boolean snsMarketingInformationReceive;
 
     @Column(name = "terms_service_agreement_modified_at")
     private LocalDateTime termsServiceAgreementModifiedAt;
@@ -41,7 +41,7 @@ public class Subscription {
     private LocalDateTime snsMarketingInformationReceiveModifiedAt;
 
     @Builder
-    public Subscription(boolean termsService, boolean privateInformationCollection, boolean snsMarketingInformationReceive) {
+    public Subscription(Boolean termsService, Boolean privateInformationCollection, Boolean snsMarketingInformationReceive) {
         LocalDateTime now = LocalDateTime.now().truncatedTo(ChronoUnit.SECONDS);
 
         this.termsService = termsService;

--- a/aptner/src/main/java/com/fastcampus/aptner/member/dto/reqeust/JoinMemberRequest.java
+++ b/aptner/src/main/java/com/fastcampus/aptner/member/dto/reqeust/JoinMemberRequest.java
@@ -9,11 +9,11 @@ import lombok.Getter;
 @Getter
 public class JoinMemberRequest {
 
-    private final boolean termsService; // 서비스 이용 약관 동의
+    private final Boolean termsService; // 서비스 이용 약관 동의
 
-    private final boolean privateInformationCollection; // 개인 정보 수집 동의
+    private final Boolean privateInformationCollection; // 개인 정보 수집 동의
 
-    private final boolean snsMarketingInformationReceive; // SNS 마케팅 정보 수신 동의는 선택입니다.
+    private final Boolean snsMarketingInformationReceive; // SNS 마케팅 정보 수신 동의는 선택입니다.
 
     @NotBlank(message = "이름: 필수 정보입니다.")
     @Pattern(regexp = "^[a-zA-Z가-힣]{1,16}$", message = "이름: 1자 이상 16자 이하의 이름을 입력해주세요.")
@@ -71,7 +71,7 @@ public class JoinMemberRequest {
 
 
     @Builder
-    public JoinMemberRequest(boolean termsService, boolean privateInformationCollection, boolean snsMarketingInformationReceive, String fullName, String birthFirst, String gender, String phoneCarrier, String phone, String username, String password, String nickname, String dong, String ho, String apartmentName) {
+    public JoinMemberRequest(Boolean termsService, Boolean privateInformationCollection, Boolean snsMarketingInformationReceive, String fullName, String birthFirst, String gender, String phoneCarrier, String phone, String username, String password, String nickname, String dong, String ho, String apartmentName) {
         this.termsService = termsService;
         this.privateInformationCollection = privateInformationCollection;
         this.snsMarketingInformationReceive = snsMarketingInformationReceive;

--- a/aptner/src/main/java/com/fastcampus/aptner/member/dto/response/LoginMemberResponse.java
+++ b/aptner/src/main/java/com/fastcampus/aptner/member/dto/response/LoginMemberResponse.java
@@ -1,4 +1,4 @@
-package com.fastcampus.aptner.member.dto.reqeust;
+package com.fastcampus.aptner.member.dto.response;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/aptner/src/main/java/com/fastcampus/aptner/member/service/JoinMemberServiceImpl.java
+++ b/aptner/src/main/java/com/fastcampus/aptner/member/service/JoinMemberServiceImpl.java
@@ -102,9 +102,9 @@ public class JoinMemberServiceImpl implements JoinMemberService {
 
         // Subscription 엔티티 생성하기
         Subscription subscription = Subscription.builder()
-                .termsService(request.isTermsService())
-                .privateInformationCollection(request.isPrivateInformationCollection())
-                .snsMarketingInformationReceive(request.isSnsMarketingInformationReceive())
+                .termsService(request.getTermsService())
+                .privateInformationCollection(request.getPrivateInformationCollection())
+                .snsMarketingInformationReceive(request.getSnsMarketingInformationReceive())
                 .build();
         subscriptionRepository.save(subscription);
 


### PR DESCRIPTION
## Description
리프레시 토큰을 재발급하면 에러가 계속 발생한 문제를 해결했다. 포스트 맨의 헤더 안에 오래된 토큰이 존재한 것이 문제였다. 이 문제를 해결하기 위해 1. 토큰 시간, 2. 토큰 저장소 길이 증가, 3. 리프레시 토큰 전략 에 대해 수정을 진행했다. 

지금은 쉽게 개발하고자 액세스 토큰과 리프레시 토큰 안에 값은 동일하도록 설정했다.

## To Reviewers
@cutegyuseok @NaSJ93 